### PR TITLE
switch to new Activity.enableEdgeToEdge

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -131,7 +131,6 @@ dependencies {
     implementation(libs.compose.animation)
     implementation(libs.compose.material3)
     implementation(libs.compose.material3.windowSizeClass)
-    implementation(libs.accompanist.systemuicontroller)
     implementation(libs.accompanist.testharness)
     implementation(libs.lifecycle.viewModel.compose)
     implementation(libs.lifecycle.viewModel.savedstate)

--- a/app/src/main/kotlin/com/mitch/appname/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/mitch/appname/ui/theme/Theme.kt
@@ -5,8 +5,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 val DarkColorScheme = darkColorScheme()
 val LightColorScheme = lightColorScheme()
@@ -20,21 +18,6 @@ fun AppMaterialTheme(
         DarkColorScheme
     } else {
         LightColorScheme
-    }
-
-    /**
-     * Use this if [Navigation bar](https://m3.material.io/components/navigation-bar/overview) (with tonal elevation) is used
-     */
-    // val navigationBarColor = MaterialTheme.colorScheme.surfaceColorAtElevation(NavigationBarDefaults.Elevation)
-
-    val systemUiController = rememberSystemUiController()
-    // Update the dark content of the system bars to match the theme
-    DisposableEffect(systemUiController, isThemeDark) {
-        systemUiController.setSystemBarsColor(
-            color = colorScheme.background,
-            darkIcons = !isThemeDark
-        )
-        onDispose {}
     }
 
     MaterialTheme(

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="NightAdjusted.Theme.Template" parent="android:Theme.Material.NoActionBar">
-        <item name="android:windowLightStatusBar" tools:targetApi="23">false</item>
-        <item name="android:windowLightNavigationBar" tools:targetApi="27">false</item>
-        <!-- has to be the same as background in Theme.kt -->
-        <item name="android:windowBackground">@color/neutral10_material3</item>
-    </style>
+
+    <style name="NightAdjusted.Theme.Template" parent="android:Theme.Material.NoActionBar" />
 
     <style name="NightAdjusted.Theme.Splash" parent="Theme.SplashScreen">
         <item name="android:windowLightStatusBar" tools:targetApi="23">false</item>

--- a/app/src/main/res/values-v23/themes.xml
+++ b/app/src/main/res/values-v23/themes.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="PlatformAdjusted.Theme.Template" parent="NightAdjusted.Theme.Template">
-        <item name="android:statusBarColor">@android:color/transparent</item>
-    </style>
-</resources>

--- a/app/src/main/res/values-v27/themes.xml
+++ b/app/src/main/res/values-v27/themes.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="PlatformAdjusted.Theme.Template" parent="NightAdjusted.Theme.Template">
-        <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
-    </style>
-</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,17 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="NightAdjusted.Theme.Template" parent="android:Theme.Material.Light.NoActionBar">
-        <item name="android:windowLightStatusBar" tools:targetApi="23">true</item>
-        <item name="android:windowLightNavigationBar" tools:targetApi="27">true</item>
-    </style>
-
-    <style name="PlatformAdjusted.Theme.Template" parent="NightAdjusted.Theme.Template">
-        <item name="android:statusBarColor">@color/neutral10_material3</item>
-    </style>
+    <style name="NightAdjusted.Theme.Template" parent="android:Theme.Material.Light.NoActionBar" />
 
     <!-- The final theme we use -->
-    <style name="Theme.Template" parent="PlatformAdjusted.Theme.Template" />
+    <style name="Theme.Template" parent="NightAdjusted.Theme.Template" />
 
     <style name="NightAdjusted.Theme.Splash" parent="Theme.SplashScreen">
         <item name="android:windowLightStatusBar" tools:targetApi="23">true</item>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlinx-coroutines = "1.7.3"
 # UI
 compose-bom = "2023.09.00"
 accompanist = "0.33.0-alpha"
-activity-compose = "1.7.2"
+activity-compose = "1.8.2"
 compose = "1.5.0"
 compose-compiler = "1.5.2"
 compose-material3 = "1.2.0-alpha07"
@@ -86,7 +86,6 @@ compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling
 compose-animation = { group = "androidx.compose.animation", name = "animation" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "compose-material3" }
 compose-material3-windowSizeClass = { group = "androidx.compose.material3", name = "material3-window-size-class", version.ref = "compose-material3" }
-accompanist-systemuicontroller = { group = "com.google.accompanist", name = "accompanist-systemuicontroller", version.ref = "accompanist" }
 accompanist-testharness = { group = "com.google.accompanist", name = "accompanist-testharness", version.ref = "accompanist" }
 lifecycle-viewModel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 


### PR DESCRIPTION
- moved to the new `enableEdgeToEdge` (no `systemuicontroller` anymore)
- no need to handle status bar color anymore and also versions 23 and 27 separately

N.B. followed guide from [Now In Android PR](https://github.com/android/nowinandroid/pull/817)