### PR TITLE
Fix splash darkmode based on user choice

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,5 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <!-- status bar -->
-    <color name="neutral10_material3">#1C1B1F</color>
-</resources>
+<resources />


### PR DESCRIPTION
When user selects a new in-app theme, splashscreen does not reflect this choice by default.
So, by adding `UiModeManager` splashscreen displays theme correctly