### PR TITLE
Encrypted datastore

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
     compileSdk = 34
     defaultConfig {
         applicationId = packageName
-        minSdk = 21
+        minSdk = 23
         targetSdk = 34
         versionCode = 1
         versionName = "0.0.1" // X.Y.Z; X = Major, Y = minor, Z = Patch level
@@ -126,6 +126,7 @@ dependencies {
     implementation(libs.core.splashscreen)
     implementation(libs.appcompat)
     implementation(libs.skeletonLoader)
+    implementation(libs.security.cryptoKtx)
 
     // Navigation
     implementation(libs.compose.destinations.core)
@@ -145,6 +146,7 @@ dependencies {
 
     // Datastore (previously SharedPreferences)
     implementation(libs.datastore.core)
+    implementation(libs.encryptedDatastore)
 
     // Logging
     implementation(libs.timber)

--- a/app/config/detekt/detekt.yml
+++ b/app/config/detekt/detekt.yml
@@ -872,11 +872,11 @@ formatting:
     active: true
     autoCorrect: true
   TrailingCommaOnCallSite:
-    active: false
+    active: true
     autoCorrect: true
     useTrailingCommaOnCallSite: false
   TrailingCommaOnDeclarationSite:
-    active: false
+    active: true
     autoCorrect: true
     useTrailingCommaOnDeclarationSite: false
   TypeArgumentListSpacing:

--- a/app/src/main/kotlin/com/mitch/appname/MainActivity.kt
+++ b/app/src/main/kotlin/com/mitch/appname/MainActivity.kt
@@ -138,7 +138,7 @@ class MainActivity : AppCompatActivity() {
 
                             DestinationsNavHost(
                                 navGraph = NavGraphs.root,
-                                navController = appState.navController,
+                                navController = appState.navController
 
                                 // to provide snackbar lambda to invoke in "@Composable"s
                                 /*dependenciesContainerBuilder = {
@@ -158,12 +158,12 @@ class MainActivity : AppCompatActivity() {
             enableEdgeToEdge(
                 statusBarStyle = SystemBarStyle.auto(
                     Color.TRANSPARENT,
-                    Color.TRANSPARENT,
+                    Color.TRANSPARENT
                 ) { isThemeDark },
                 navigationBarStyle = SystemBarStyle.auto(
                     lightScrim,
-                    darkScrim,
-                ) { isThemeDark },
+                    darkScrim
+                ) { isThemeDark }
             )
             onDispose { }
         }
@@ -256,7 +256,7 @@ private fun SwipeToDismissSnackbarHost(
 
 @Composable
 private fun shouldUseDarkTheme(
-    uiState: MainActivityUiState,
+    uiState: MainActivityUiState
 ): Boolean = when (uiState) {
     MainActivityUiState.Loading -> isSystemInDarkTheme()
     is MainActivityUiState.Success -> when (uiState.theme) {

--- a/app/src/main/kotlin/com/mitch/appname/di/DatastoreModule.kt
+++ b/app/src/main/kotlin/com/mitch/appname/di/DatastoreModule.kt
@@ -23,7 +23,7 @@ object DatastoreModule {
     @Singleton
     fun providesUserPreferencesDatastore(
         @ApplicationContext context: Context,
-        userPreferencesSerializer: UserPreferencesSerializer,
+        userPreferencesSerializer: UserPreferencesSerializer
     ): DataStore<UserPreferences> =
         DataStoreFactory.create(
             serializer = userPreferencesSerializer,

--- a/app/src/main/kotlin/com/mitch/appname/ui/AppState.kt
+++ b/app/src/main/kotlin/com/mitch/appname/ui/AppState.kt
@@ -25,7 +25,7 @@ fun rememberAppState(
     networkMonitor: NetworkMonitor,
     navController: NavHostController = rememberNavController(),
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
-    coroutineScope: CoroutineScope = rememberCoroutineScope(),
+    coroutineScope: CoroutineScope = rememberCoroutineScope()
 ): AppState {
     return remember(navController, snackbarHostState, coroutineScope, networkMonitor) {
         AppState(navController, snackbarHostState, coroutineScope, networkMonitor)

--- a/app/src/main/kotlin/com/mitch/appname/util/network/ConnectivityManagerNetworkMonitor.kt
+++ b/app/src/main/kotlin/com/mitch/appname/util/network/ConnectivityManagerNetworkMonitor.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.conflate
 import javax.inject.Inject
 
 class ConnectivityManagerNetworkMonitor @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @ApplicationContext private val context: Context
 ) : NetworkMonitor {
     override val isOnline: Flow<Boolean> = callbackFlow {
         val connectivityManager = context.getSystemService<ConnectivityManager>()
@@ -38,7 +38,7 @@ class ConnectivityManagerNetworkMonitor @Inject constructor(
 
             override fun onCapabilitiesChanged(
                 network: Network,
-                networkCapabilities: NetworkCapabilities,
+                networkCapabilities: NetworkCapabilities
             ) {
                 channel.trySend(connectivityManager.isCurrentlyConnected())
             }
@@ -48,7 +48,7 @@ class ConnectivityManagerNetworkMonitor @Inject constructor(
             Builder()
                 .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
                 .build(),
-            callback,
+            callback
         )
 
         channel.trySend(connectivityManager.isCurrentlyConnected())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ eva = "1.0.0"
 core-splashscreen = "1.0.1"
 appcompat = "1.6.1"
 eygraber-placeholder-m3 = "1.0.7"
+security-cryptoKtx = "1.1.0-alpha06"
 
 # Navigation
 compose-destinations = "1.9.62" # check compose version
@@ -30,6 +31,7 @@ room = "2.6.1"
 
 # Datastore
 datastore = "1.0.0"
+encryptedDatastore = "1.0.0-beta01"
 
 # Logging
 timber = "5.0.1"
@@ -105,6 +107,7 @@ icons-eva = { group = "br.com.devsrsouza.compose.icons.android", name = "eva-ico
 core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "core-splashscreen" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 skeletonLoader = { group = "com.eygraber", name = "compose-placeholder-material3", version.ref = "eygraber-placeholder-m3" }
+security-cryptoKtx = { group = "androidx.security", name = "security-crypto-ktx", version.ref = "security-cryptoKtx" }
 
 # Navigation
 compose-destinations-core = { group = "io.github.raamcosta.compose-destinations", name = "core", version.ref = "compose-destinations" }
@@ -125,6 +128,7 @@ room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "
 
 # Datastore
 datastore-core = { group = "androidx.datastore", name = "datastore", version.ref = "datastore" }
+encryptedDatastore = { group = "io.github.osipxd", name = "security-crypto-datastore", version.ref = "encryptedDatastore" }
 
 # Logging
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }


### PR DESCRIPTION
Added encrypted datastore strategy via [`encrypted-datastore`](https://github.com/osipxd/encrypted-datastore/tree/main) library. It's an interim solution until an official one is released ([see feature request](https://issuetracker.google.com/issues/167697691?pli=1)).

Combined with [`security-crypto-ktx`](https://developer.android.com/jetpack/androidx/releases/security) that provides an encrypted file solution, it's the best way to quickly create a fully-encrypted datastore.

N.B. `minSdk` had to be upgraded from 21 to 23 to match `security-crypto-ktx`'s `minSdk`

This resolves #6.