### PR TITLE
lower minSdk to 21 following security-crypto deprecation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
     compileSdk = 34
     defaultConfig {
         applicationId = packageName
-        minSdk = 23
+        minSdk = 21
         targetSdk = 34
         versionCode = 1
         versionName = "0.0.1" // X.Y.Z; X = Major, Y = minor, Z = Patch level


### PR DESCRIPTION
After deprecating `security-crypto` in #24, `minSdk` can be lowered from 23 (minSdk for security-crypto) to 21 (minSdk for Compose).