### PR TITLE
Migrate to Square's Wire proto implementation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     alias(libs.plugins.junit5)
     alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.protobuf)
+    alias(libs.plugins.square.wire)
 }
 
 val packageName = "com.mitch.template"
@@ -246,21 +246,9 @@ tasks.withType<dev.detekt.gradle.DetektCreateBaselineTask>().configureEach {
     jvmTarget = JvmTarget.JVM_17.target
 }
 
-protobuf {
-    protoc {
-        artifact = libs.protobuf.protoc.get().toString()
-    }
-    generateProtoTasks {
-        all().forEach { task ->
-            task.builtins {
-                register("java") {
-                    option("lite")
-                }
-                register("kotlin") {
-                    option("lite")
-                }
-            }
-        }
+wire {
+    kotlin {
+        android = true
     }
 }
 
@@ -308,7 +296,6 @@ dependencies {
 
     // Datastore (previously SharedPreferences)
     implementation(libs.datastore.core)
-    implementation(libs.protobuf.kotlin.lite)
 
     // Logging
     implementation(libs.timber)

--- a/app/src/main/kotlin/com/mitch/template/data/settings/DefaultUserSettingsRepository.kt
+++ b/app/src/main/kotlin/com/mitch/template/data/settings/DefaultUserSettingsRepository.kt
@@ -26,10 +26,10 @@ class DefaultUserSettingsRepository(
         .map { protoPreferences ->
             TemplateUserPreferences(
                 theme = protoPreferences.theme.toDomainModel(),
-                language = if (protoPreferences.locale.isEmpty()) {
+                language = if (protoPreferences.locale?.isEmpty() == true) {
                     TemplateLanguagePreference.FollowSystem
                 } else {
-                    val locale = Locale.forLanguageTag(protoPreferences.locale)
+                    val locale = Locale.forLanguageTag(protoPreferences.locale.orEmpty())
                     locale.toDomainModel()
                 }
             )

--- a/app/src/main/kotlin/com/mitch/template/data/userprefs/UserPreferencesLocalDataSource.kt
+++ b/app/src/main/kotlin/com/mitch/template/data/userprefs/UserPreferencesLocalDataSource.kt
@@ -18,25 +18,19 @@ class UserPreferencesLocalDataSource(
 
     suspend fun setTheme(theme: TemplateThemePreferenceProto) {
         userPreferences.updateData {
-            it.copy {
-                this.theme = theme
-            }
+            it.copy(theme = theme)
         }
     }
 
     suspend fun setLocale(locale: Locale) {
         userPreferences.updateData {
-            it.copy {
-                this.locale = locale.toLanguageTag()
-            }
+            it.copy(locale = locale.toLanguageTag())
         }
     }
 
     suspend fun resetLocale() {
         userPreferences.updateData {
-            it.copy {
-                clearLocale()
-            }
+            it.copy(locale = null)
         }
     }
 }

--- a/app/src/main/kotlin/com/mitch/template/data/userprefs/UserPreferencesSerializer.kt
+++ b/app/src/main/kotlin/com/mitch/template/data/userprefs/UserPreferencesSerializer.kt
@@ -2,7 +2,7 @@ package com.mitch.template.data.userprefs
 
 import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.Serializer
-import kotlinx.serialization.SerializationException
+import kotlinx.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 
@@ -13,20 +13,19 @@ import java.io.OutputStream
  * see more at [Proto Datastore](https://developer.android.com/topic/libraries/architecture/datastore#proto-create)
  */
 object UserPreferencesSerializer : Serializer<UserPreferencesProtoModel> {
-    override val defaultValue: UserPreferencesProtoModel =
-        UserPreferencesProtoModel.getDefaultInstance()
+    override val defaultValue: UserPreferencesProtoModel = UserPreferencesProtoModel()
 
     override suspend fun readFrom(input: InputStream): UserPreferencesProtoModel {
         return try {
             // readFrom is already called on the data store background thread
-            UserPreferencesProtoModel.parseFrom(input)
-        } catch (exception: SerializationException) {
+            UserPreferencesProtoModel.ADAPTER.decode(input)
+        } catch (exception: IOException) {
             throw CorruptionException("Cannot read proto. $exception")
         }
     }
 
     override suspend fun writeTo(t: UserPreferencesProtoModel, output: OutputStream) {
         // writeTo is already called on the data store background thread
-        t.writeTo(output)
+        UserPreferencesProtoModel.ADAPTER.encode(output, t)
     }
 }

--- a/app/src/main/kotlin/com/mitch/template/data/userprefs/UserPrefsMapper.kt
+++ b/app/src/main/kotlin/com/mitch/template/data/userprefs/UserPrefsMapper.kt
@@ -12,6 +12,5 @@ fun TemplateThemePreference.toProtoModel(): TemplateThemePreferenceProto = when 
 fun TemplateThemePreferenceProto.toDomainModel(): TemplateThemePreference = when (this) {
     TemplateThemePreferenceProto.LIGHT -> TemplateThemePreference.Light
     TemplateThemePreferenceProto.DARK -> TemplateThemePreference.Dark
-    TemplateThemePreferenceProto.UNRECOGNIZED,
     TemplateThemePreferenceProto.FOLLOW_SYSTEM -> TemplateThemePreference.FollowSystem
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,5 +8,5 @@ plugins {
     alias(libs.plugins.kotlinx.serialization) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.android.lint) apply false
-    alias(libs.plugins.protobuf) apply false
+    alias(libs.plugins.square.wire) apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,3 @@ kotlin.code.style=official
 
 # Enable R8 full mode.
 android.enableR8.fullMode=true
-
-# Blockers:
-# - https://github.com/google/protobuf-gradle-plugin/issues/787
-android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,8 +24,9 @@ room = "2.8.4"
 
 # Datastore
 datastore = "1.2.1"
-protobuf = "4.34.0"
-protobufPlugin = "0.9.6"
+
+# Proto
+square-wire = "6.0.0"
 
 # Logging
 timber = "5.0.1"
@@ -115,8 +116,6 @@ room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "
 
 # Datastore
 datastore-core = { group = "androidx.datastore", name = "datastore", version.ref = "datastore" }
-protobuf-kotlin-lite = { group = "com.google.protobuf", name = "protobuf-kotlin-lite", version.ref = "protobuf" }
-protobuf-protoc = { group = "com.google.protobuf", name = "protoc", version.ref = "protobuf" }
 
 # Logging
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
@@ -173,4 +172,4 @@ junit5 = { id = "de.mannodermaus.android-junit5", version.ref = "junit5-plugin" 
 android-test = { id = "com.android.test", version.ref = "android-gradle-plugin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 android-lint = { id = "com.android.lint", version.ref = "android-gradle-plugin" }
-protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
+square-wire = { id = "com.squareup.wire", version.ref = "square-wire" }


### PR DESCRIPTION
As noted in [this GitHub issue](https://github.com/google/protobuf-gradle-plugin/issues/793#issuecomment-3803557086), the recommended path forward for removing the `android.newDsl=false` flag is to migrate to [Square's Wire](https://square.github.io/wire/) for the Proto implementation.